### PR TITLE
feat: YOLO→ViT 5클래스 FastAPI 파이프라인 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,53 @@
+# Python
 __pycache__/
-*.pyc
-.venv/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
 venv/
+ENV/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
 .env
-.env.*
-.DS_Store
+.venv
+venv/
+ENV/
+
+# IDEs
 .vscode/
 .idea/
-data/
-datasets/
-weights/
-checkpoints/
-runs/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Model files (too large)
+*.pt
+*.pth
+*.onnx
+*.pb
+
+# Test files
+test_*.py

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -1,0 +1,261 @@
+# Spring + FastAPI 연동 가이드
+
+## 📋 개요
+
+Spring Backend (Batch Rental System) ↔ FastAPI ML Server
+
+## 🔗 연동 스펙
+
+### 1. API Contract
+
+**Endpoint**: `POST http://127.0.0.1:8001/predict`
+
+**Spring → FastAPI Request:**
+```json
+{
+  "raw_url": "https://minio-presigned-get-url",
+  "yoloThreshold": 0.3,
+  "heatmap_put_url": "https://minio-presigned-put-url"
+}
+```
+
+**FastAPI → Spring Response:**
+```json
+{
+  "model": "yolo-vit",
+  "threshold_used": 0.3,
+  "boxes": [
+    {
+      "class_probs": [
+        {"label": "BREAKAGE", "prob": 0.71},
+        {"label": "CRUSHED", "prob": 0.11},
+        {"label": "SCRATCHED", "prob": 0.10},
+        {"label": "SEPARATED", "prob": 0.08}
+      ],
+      "x": 0.102,
+      "y": 0.214,
+      "w": 0.265,
+      "h": 0.180
+    }
+  ]
+}
+```
+
+### 2. Spring DamageType Enum
+
+```java
+public enum DamageType {
+    BREAKAGE,   // ViT index 0
+    CRUSHED,    // ViT index 1
+    SCRATCHED,  // ViT index 2
+    SEPARATED   // ViT index 3
+    // NORMAL (index 4) is filtered out by FastAPI
+}
+```
+
+### 3. Spring DTO 매핑
+
+**FastApiPredictRes.java:**
+```java
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FastApiPredictRes(
+    String model,
+    
+    @JsonProperty("threshold_used")
+    Double thresholdUsed,
+    
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    List<BoxDto> boxes
+) {}
+```
+
+**BoxDto.java:**
+```java
+public record BoxDto(
+    @JsonProperty("class_probs")
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    List<ClassProbDto> classProbs,
+    
+    Double x,  // 0-1 normalized
+    Double y,  // 0-1 normalized
+    Double w,  // 0-1 normalized
+    Double h   // 0-1 normalized
+) {}
+```
+
+**ClassProbDto.java:**
+```java
+public record ClassProbDto(
+    DamageType label,  // BREAKAGE | CRUSHED | SCRATCHED | SEPARATED
+    Double prob        // 0.0 - 1.0
+) {}
+```
+
+## 🔧 Spring Configuration
+
+**application.yml:**
+```yaml
+fastapi:
+  base-url: http://127.0.0.1:8001
+  timeout:
+    connect: 5s
+    read: 30s
+    write: 30s
+  predict-endpoint: /predict
+```
+
+## 🚀 시작 순서
+
+### 1. FastAPI 서버 시작 (먼저!)
+
+```bash
+cd fastapi_new
+uvicorn main:app --host 127.0.0.1 --port 8001 --reload --env-file .env
+```
+
+또는 VSCode에서 F5
+
+### 2. Spring 서버 시작
+
+```bash
+cd capstone-web
+./gradlew bootRun
+```
+
+또는 IntelliJ에서 실행
+
+## 🧪 연동 테스트
+
+### Step 1: 이미지 업로드
+
+```http
+POST http://localhost:8888/api/images
+Content-Type: multipart/form-data
+
+file: [car-image.jpg]
+```
+
+### Step 2: 예측 요청
+
+```http
+POST http://localhost:8888/api/predictions/by-image/{imageId}
+```
+
+Spring이 자동으로:
+1. MinIO presigned URL 생성
+2. FastAPI에 /predict 요청
+3. 결과 파싱 및 저장
+
+## ⚠️ 주의사항
+
+### 1. NORMAL 클래스 처리
+
+FastAPI는 ViT가 NORMAL(index 4)로 분류한 박스를 **완전히 제거**합니다.
+Spring은 NORMAL에 대한 DamageType enum이 **없습니다**.
+
+### 2. class_probs 배열
+
+항상 **정확히 4개**의 요소를 포함합니다:
+- BREAKAGE (index 0)
+- CRUSHED (index 1)
+- SCRATCHED (index 2)
+- SEPARATED (index 3)
+
+합계는 항상 **1.0**입니다 (softmax 재계산).
+
+### 3. 빈 boxes 배열
+
+손상이 없거나 모든 박스가 NORMAL인 경우:
+```json
+{
+  "model": "yolo-vit",
+  "threshold_used": 0.3,
+  "boxes": []
+}
+```
+
+**절대 `null`이 아님!** Spring은 `@JsonSetter(nulls = Nulls.AS_EMPTY)`로 처리.
+
+### 4. 히트맵 업로드
+
+- 박스가 **1개 이상** 남아있을 때만 업로드
+- 모든 박스가 NORMAL이면 히트맵 생성 안 함
+- 업로드 실패는 200 OK 응답에 영향 없음 (경고 로그만)
+
+## 🐛 트러블슈팅
+
+### 문제 1: Connection refused
+
+**증상**: Spring → FastAPI 연결 실패
+
+**해결**:
+```bash
+# FastAPI 서버 실행 확인
+curl http://127.0.0.1:8001/health
+
+# 정상 응답:
+{
+  "status": "healthy",
+  "device": "mps",
+  "models_loaded": true
+}
+```
+
+### 문제 2: DamageType 역직렬화 실패
+
+**증상**: 
+```
+Cannot deserialize value of type `DamageType` from String "NORMAL"
+```
+
+**원인**: FastAPI가 NORMAL을 반환함
+
+**해결**: FastAPI 업데이트 (main.py의 필터링 로직 확인)
+
+### 문제 3: boxes가 null
+
+**증상**: NullPointerException in Spring
+
+**해결**: FastAPI는 빈 배열 `[]` 반환, Spring DTO에 `@JsonSetter(nulls = Nulls.AS_EMPTY)` 추가
+
+## 📊 성능 참고
+
+- YOLO 추론: ~100-200ms (MPS/CUDA)
+- ViT 추론 (per box): ~50-100ms
+- 전체 파이프라인 (3 boxes): ~500-800ms
+- 히트맵 생성: ~50ms
+- HTTP 오버헤드: ~10-20ms
+
+## 🔍 로그 예시
+
+**FastAPI:**
+```
+INFO: Downloaded image: (800, 600)
+INFO: YOLO detected 5 boxes
+DEBUG: Box 1 filtered (NORMAL)
+DEBUG: Box 2: class_probs=[BREAKAGE: 0.71, ...]
+INFO: Final boxes after ViT filtering: 3
+INFO: Generating heatmap...
+INFO: Heatmap uploaded successfully
+```
+
+**Spring:**
+```
+INFO: Requesting prediction for imageId=123
+DEBUG: FastAPI request: {raw_url=..., yoloThreshold=0.3}
+DEBUG: FastAPI response: 3 boxes detected
+INFO: Saved prediction with 3 detections
+```
+
+## ✅ 체크리스트
+
+연동 전 확인사항:
+
+- [ ] FastAPI 서버 실행 중 (port 8001)
+- [ ] Spring application.yml에 fastapi.base-url 설정
+- [ ] MinIO 실행 중 (presigned URL 생성용)
+- [ ] 모델 파일 경로 정확 (.env 설정)
+- [ ] CUDA/MPS 사용 가능 (선택)
+- [ ] /health 엔드포인트 정상 응답
+- [ ] DamageType enum에 NORMAL 없음 확인
+- [ ] Spring DTO에 @JsonSetter(nulls = Nulls.AS_EMPTY) 있음

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,256 @@
+# 🚀 빠른 시작 가이드
+
+## 1️⃣ 프로젝트 구조
+
+```
+fastapi_new/
+├── main.py                 # FastAPI 메인 애플리케이션
+├── requirements.txt        # Python 의존성
+├── .env                    # 환경 변수 (모델 경로)
+├── .vscode/
+│   └── launch.json        # VSCode 디버그 설정
+├── README.md              # 프로젝트 문서
+├── INTEGRATION.md         # Spring 연동 가이드
+├── test_api.py            # API 테스트 스크립트
+└── .gitignore             # Git 무시 파일
+```
+
+## 2️⃣ 설치 및 실행 (3분)
+
+### Step 1: 의존성 설치
+
+```bash
+cd fastapi_new
+pip install -r requirements.txt
+```
+
+### Step 2: 모델 경로 확인
+
+`.env` 파일 열어서 경로 확인:
+
+```env
+YOLO_WEIGHTS=/Users/dopal0426/Desktop/dev/model/failed_yolo/best.pt
+VIT_WEIGHTS=/Users/dopal0426/Desktop/dev/model/main_vit_model/focal_loss.pth
+```
+
+### Step 3: 서버 실행
+
+#### 방법 A: VSCode (권장)
+
+1. VSCode로 `fastapi_new` 폴더 열기
+2. **F5** 키 누르기
+3. "FastAPI (uvicorn, 8001)" 선택
+4. 터미널에서 "Application startup complete" 확인
+
+#### 방법 B: 커맨드 라인
+
+```bash
+uvicorn main:app --host 127.0.0.1 --port 8001 --reload --env-file .env
+```
+
+### Step 4: 동작 확인
+
+브라우저에서 열기:
+- Health check: http://127.0.0.1:8001/health
+- API docs: http://127.0.0.1:8001/docs
+
+## 3️⃣ 주요 변경사항 (이전 버전 대비)
+
+### ViT 클래스 변경
+
+**이전:**
+```python
+["CAR_DAMAGE", "DENT", "GLASS_BREAK", "SCRATCH"]
+```
+
+**새로운:**
+```python
+0: "BREAKAGE"
+1: "CRUSHED"
+2: "SCRATCHED"
+3: "SEPARATED"
+4: "NORMAL"  # ← 새로 추가, 필터링됨
+```
+
+### NORMAL 필터링
+
+```python
+# ViT 결과가 NORMAL(index 4)이면 박스 제거
+if top1_idx == 4:
+    continue  # Skip this box
+
+# 나머지 박스는 4개 손상 클래스(0-3)만 softmax 재계산
+damage_logits = logits[:4]  # Exclude NORMAL
+damage_probs = F.softmax(damage_logits, dim=0)
+```
+
+### API 스펙 단순화
+
+**Request:**
+```json
+{
+  "raw_url": "...",
+  "yoloThreshold": 0.3,       // ← 단순화 (yolo_conf → yoloThreshold)
+  "heatmap_put_url": "..."    // optional
+}
+```
+
+**Response:**
+```json
+{
+  "model": "yolo-vit",
+  "threshold_used": 0.3,      // ← snake_case
+  "boxes": [
+    {
+      "class_probs": [        // ← 항상 4개
+        {"label": "BREAKAGE", "prob": 0.71},
+        {"label": "CRUSHED", "prob": 0.11},
+        {"label": "SCRATCHED", "prob": 0.10},
+        {"label": "SEPARATED", "prob": 0.08}
+      ],
+      "x": 0.102, "y": 0.214, "w": 0.265, "h": 0.180
+    }
+  ]
+}
+```
+
+## 4️⃣ Spring 연동
+
+### Spring 설정
+
+**application.yml:**
+```yaml
+fastapi:
+  base-url: http://127.0.0.1:8001
+  predict-endpoint: /predict
+```
+
+### 실행 순서
+
+1. **FastAPI 먼저** 시작 (port 8001)
+2. **Spring 나중에** 시작 (port 8888)
+
+### 동작 흐름
+
+```
+[Spring] 이미지 업로드
+   ↓
+[Spring] MinIO presigned URL 생성
+   ↓
+[Spring] POST /predict to FastAPI
+   ↓
+[FastAPI] 이미지 다운로드 → YOLO → ViT → 필터링
+   ↓
+[FastAPI] 히트맵 생성 & 업로드 (optional)
+   ↓
+[FastAPI] Response to Spring
+   ↓
+[Spring] 결과 저장
+```
+
+## 5️⃣ 테스트
+
+### Health Check
+
+```bash
+curl http://127.0.0.1:8001/health
+```
+
+**Expected:**
+```json
+{
+  "status": "healthy",
+  "device": "mps",
+  "models_loaded": true
+}
+```
+
+### Prediction Test
+
+```bash
+python test_api.py
+```
+
+**또는 수동:**
+```bash
+curl -X POST http://127.0.0.1:8001/predict \
+  -H "Content-Type: application/json" \
+  -d '{
+    "raw_url": "https://your-presigned-url",
+    "yoloThreshold": 0.3
+  }'
+```
+
+## 6️⃣ 트러블슈팅
+
+### 문제: 모델 로딩 실패
+
+```
+FileNotFoundError: [Errno 2] No such file or directory: '/Users/...'
+```
+
+**해결:** `.env` 파일의 모델 경로 확인
+
+### 문제: CUDA out of memory
+
+```
+RuntimeError: CUDA out of memory
+```
+
+**해결:** `.env`에 추가:
+```env
+PYTORCH_MPS_ENABLED=1  # M1/M2 Mac
+```
+
+또는 CPU 강제:
+```python
+DEVICE = "cpu"
+```
+
+### 문제: Connection refused (Spring)
+
+```
+ConnectException: Connection refused
+```
+
+**해결:** FastAPI 서버가 실행 중인지 확인:
+```bash
+curl http://127.0.0.1:8001/health
+```
+
+## 7️⃣ 다음 단계
+
+1. ✅ FastAPI 서버 실행 확인
+2. ✅ /health 테스트
+3. ✅ Spring 서버 시작
+4. ✅ 이미지 업로드 테스트
+5. ✅ 예측 요청 테스트
+6. ✅ 히트맵 확인 (MinIO)
+
+## 📚 추가 문서
+
+- **README.md**: 전체 프로젝트 개요
+- **INTEGRATION.md**: Spring 연동 상세 가이드
+- **main.py**: 소스 코드 (주석 참고)
+
+## 🆘 도움말
+
+문제 발생 시:
+1. 로그 확인 (터미널 출력)
+2. `/health` 엔드포인트 테스트
+3. 모델 파일 경로 확인
+4. Python 버전 확인 (3.11+)
+5. 의존성 재설치: `pip install -r requirements.txt --upgrade`
+
+## ✨ 주요 기능
+
+- ✅ YOLO object detection
+- ✅ ViT classification (5 classes)
+- ✅ NORMAL filtering (automatic)
+- ✅ Softmax recalculation (damage classes only)
+- ✅ Normalized coordinates (0-1)
+- ✅ Heatmap generation
+- ✅ MinIO presigned URL support
+- ✅ Contract-compliant API (Spring compatible)
+- ✅ GPU acceleration (CUDA/MPS)
+- ✅ Hot reload (development)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,130 @@
+# Vehicle Damage Detection API (Batch Rental System)
+
+FastAPI 서버 for YOLO + ViT 손상 탐지 파이프라인
+
+## 📋 Requirements
+
+- Python 3.11+
+- CUDA (optional, for GPU acceleration)
+- MPS (optional, for Apple Silicon)
+
+## 🚀 Setup
+
+### 1. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Configure model paths
+
+Edit `.env` file:
+
+```env
+YOLO_WEIGHTS=/Users/dopal0426/Desktop/dev/model/failed_yolo/best.pt
+VIT_WEIGHTS=/Users/dopal0426/Desktop/dev/model/main_vit_model/focal_loss.pth
+VIT_MODEL_NAME=google/vit-base-patch16-224-in21k
+```
+
+### 3. Run server
+
+#### Option A: VSCode Debug (F5)
+
+Open in VSCode → Press F5 → Select "FastAPI (uvicorn, 8001)"
+
+#### Option B: Command line
+
+```bash
+uvicorn main:app --host 127.0.0.1 --port 8001 --reload --env-file .env
+```
+
+## 📡 API Specification
+
+### POST /predict
+
+**Request:**
+
+```json
+{
+  "raw_url": "https://presigned-get-url-for-image",
+  "yoloThreshold": 0.3,
+  "heatmap_put_url": "https://presigned-put-url-for-heatmap.png"
+}
+```
+
+**Response:**
+
+```json
+{
+  "model": "yolo-vit",
+  "threshold_used": 0.3,
+  "boxes": [
+    {
+      "class_probs": [
+        {"label": "BREAKAGE", "prob": 0.71},
+        {"label": "CRUSHED", "prob": 0.11},
+        {"label": "SCRATCHED", "prob": 0.10},
+        {"label": "SEPARATED", "prob": 0.08}
+      ],
+      "x": 0.102,
+      "y": 0.214,
+      "w": 0.265,
+      "h": 0.180
+    }
+  ]
+}
+```
+
+## 🔍 Processing Flow
+
+1. **Download image** from `raw_url`
+2. **YOLO detection** with `yoloThreshold` confidence
+3. **For each box:**
+   - Crop region
+   - ViT classification (5 classes: 0-3=damage, 4=NORMAL)
+   - If top-1 is NORMAL (index 4): **filter out** this box
+   - Otherwise: compute softmax over damage classes (0-3 only)
+4. **Normalize coordinates** (0-1 range)
+5. **Generate heatmap** (if boxes remain and `heatmap_put_url` provided)
+6. **Upload heatmap** via HTTP PUT
+7. **Return filtered boxes**
+
+## 🏷️ ViT Classes
+
+| Index | Internal Name | DamageType Enum |
+|-------|---------------|-----------------|
+| 0     | Breakage      | BREAKAGE        |
+| 1     | Crushed       | CRUSHED         |
+| 2     | Scratched     | SCRATCHED       |
+| 3     | Separated     | SEPARATED       |
+| 4     | Normal        | (filtered out)  |
+
+## 🔧 Key Features
+
+- ✅ **NORMAL filtering**: Boxes classified as NORMAL (index 4) are completely removed
+- ✅ **Softmax recalculation**: Only damage classes (0-3) are used for probability distribution
+- ✅ **Normalized coordinates**: All coordinates are in 0-1 range
+- ✅ **Contract compliance**: Response schema strictly matches Spring backend expectations
+- ✅ **Heatmap generation**: Simple colored box overlay (only when boxes remain)
+
+## 🧪 Testing
+
+```bash
+# Health check
+curl http://127.0.0.1:8001/health
+
+# Prediction (example)
+curl -X POST http://127.0.0.1:8001/predict \
+  -H "Content-Type: application/json" \
+  -d '{
+    "raw_url": "https://your-presigned-url",
+    "yoloThreshold": 0.3
+  }'
+```
+
+## 📝 Notes
+
+- Empty `boxes` array (not null) is returned when no damage detected
+- Heatmap upload failures do not affect 200 OK response (logged as warnings)
+- YOLO confidence threshold is reflected in `threshold_used` field
+- All class labels match Spring's `DamageType` enum exactly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,23 @@
+# FastAPI
+fastapi==0.109.0
+uvicorn[standard]==0.27.0
+pydantic==2.5.3
+
+# HTTP client
+httpx==0.26.0
+
+# Image processing
+Pillow==10.2.0
+opencv-python==4.9.0.80
+
+# Deep learning
+torch==2.1.2
+torchvision==0.16.2
+transformers==4.36.2
+
+# YOLO
+ultralytics==8.1.0
+
+# Utilities
+numpy==1.26.3
+python-multipart==0.0.6


### PR DESCRIPTION
Closes #2 

### Background
- 렌탈 도메인 라벨셋(BREAKAGE, CRUSHED, SCRATCHED, SEPARATED, NORMAL)에 맞춰 FastAPI 파이프라인을 5클래스 기준으로 재구성
- NORMAL은 학습에는 포함하지만, API 응답에는 손상 4종만 노출하는 형태로 Spring/프론트와 계약

### Changes
- TRAIN_ID2LABEL을 BREAKAGE/CRUSHED/NORMAL/SCRATCHED/SEPARATED 순서로 고정.
- DAMAGE_API_4(BREAKAGE, CRUSHED, SCRATCHED, SEPARATED)에 대해서만 softmax 계산 및 응답 노출.
- NORMAL이 top-1일 경우 해당 박스 필터링.
- YOLO → ViT → Grad-CAM까지 통합된 `/predict` 엔드포인트 구현.

### Notes
- Spring 렌탈 단일/배치 플로우에서 공통으로 사용하는 FastAPI 엔진으로 활용할 예정입니다.